### PR TITLE
feat(llm): make validation retry count configurable via maxValidationRetries URI parameter

### DIFF
--- a/documents/design.md
+++ b/documents/design.md
@@ -95,7 +95,7 @@ Example: `openrouter/openai/gpt-4o`, `openrouter/meta-llama/llama-3.1-8b-instruc
 - URI Parser:
   `ModelURI` class supporting `provider/model` syntax. A protocol prefix (`chat://`, `response-api://`) is accepted for backward compatibility but is ignored.
 - Warning Suppression: Global `AI_SDK_LOG_WARNINGS` control via `logVercelWarnings` URI parameter
-- Retry Logic: 3-attempt exponential backoff (1s, 2s, 4s)
+- Retry Logic: Configurable validation retry count via `maxValidationRetries` URI parameter (default 3), exponential backoff (1s, 2s, 4s). Independent from HTTP-level `maxRetries` (Vercel AI SDK).
 - Self-Correction: Retry on validation failures with error context
 - Timeout Control: Per-attempt timeout (default 30s) using AbortController. Defense-in-depth against abort/settle race condition: a `settled` flag in the timeout callback skips `abort()` if the promise already settled, and `clearTimeout` in `finally` cancels the timer. Both guards are needed because `clearTimeout` cannot cancel a callback already queued as a macrotask.
 - Parameter Support: URI defaults + per-request overrides

--- a/documents/requirements.md
+++ b/documents/requirements.md
@@ -5,7 +5,7 @@
 ### LLM Integration (FR-LLM)
 - [x] **FR-LLM-1**: Support multiple providers via `ModelURI` class with unified syntax (`provider/model?params`); protocol prefix accepted for backward compatibility but ignored
 - [x] **FR-LLM-14**: Unified `createLlmRequester()` factory in `src/llm/factory.ts` routes by provider: `openrouter` → native `@openrouter/sdk`, others → Vercel AI SDK
-- [x] **FR-LLM-2**: Implement automatic retry with exponential backoff (max 3 attempts)
+- [x] **FR-LLM-2**: Implement automatic retry with exponential backoff (default 3 attempts, configurable via `maxValidationRetries` URI parameter)
 - [x] **FR-LLM-3**: Support self-correction on JSON parsing/Zod validation failures
 - [x] **FR-LLM-4**: Provide structured generation with schema validation and conversational output
 - [x] **FR-LLM-5**: Mask sensitive parameters (apiKey) in logging output
@@ -16,7 +16,7 @@
 - [x] **FR-LLM-10**: Support `toolChoice` parameter to control tool calling behavior
 - [x] **FR-LLM-11**: Ensure `AbortController.abort()` calls are protected from listener exceptions to prevent process crashes
 - [x] **FR-LLM-12**: Support real-time streaming via `LlmRequester.stream` (`LlmStreamer` function) returning `StreamResult<T>` with `textStream`, `fullStream`, and promise-based final values
-- [x] **FR-LLM-13**: For structured output streaming, buffer and retry internally (max 3 attempts); consumer receives only the successful attempt's stream
+- [x] **FR-LLM-13**: For structured output streaming, buffer and retry internally (default 3 attempts, configurable via `maxValidationRetries`); consumer receives only the successful attempt's stream
 
 ### Agent (FR-AGENT)
 - [x] **FR-AGENT-1**: Maintain stateful conversation history (`ModelMessage[]`)

--- a/documents/vision.md
+++ b/documents/vision.md
@@ -10,7 +10,7 @@ AI Skeleton Tools (ai-skel-ts) provides robust TypeScript foundation for AI-powe
 - **Agent Ready**: Multi-step execution with tool-calling support and `toolChoice` control
 - **History Preservation**: Native return of all session messages (`newMessages`) for stateful systems
 - **Environment Config**: Provider-specific environment variables (`<PROVIDER>_API_KEY`) with URI parameter priority
-- **Enhanced Resilience**: 3-retry exponential backoff with raw response capture for self-correction
+- **Enhanced Resilience**: Configurable validation retry count (default 3, via `maxValidationRetries` URI parameter) with exponential backoff and raw response capture for self-correction
 - **Cost Transparency**: Real-time token usage and USD cost tracking
 - **Type Safety**: Zod/JSON schema validation with comprehensive error logging
 - **Deep Observability**: Step-by-step execution traces in debug logs

--- a/src/llm/llm.max-validation-retries.test.ts
+++ b/src/llm/llm.max-validation-retries.test.ts
@@ -1,0 +1,539 @@
+/**
+ * Tests for configurable maxValidationRetries via ModelURI.
+ *
+ * Covers:
+ * - Default behavior (3 retries) when parameter is omitted
+ * - Custom retry count via ?maxValidationRetries=N
+ * - Non-streaming and streaming structured retry loops
+ * - Log message reflects actual configured value
+ */
+
+import { expect } from "@std/expect";
+import { createVercelRequester, ModelURI, type LlmEngine } from "./llm.ts";
+import { NoObjectGeneratedError } from "ai";
+import type { Logger } from "../logger/logger.ts";
+import type { CostTracker } from "../cost-tracker/cost-tracker.ts";
+import type { RunContext } from "../run-context/run-context.ts";
+import { z } from "zod";
+
+// --- Helpers ---
+
+function makeTestDeps() {
+  const debugMessages: string[] = [];
+  const logger = {
+    debug: (msg: string) => { debugMessages.push(msg); },
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as unknown as Logger;
+
+  const costTracker = {
+    addCost: () => {},
+    addTokens: () => {},
+  } as unknown as CostTracker;
+
+  return { logger, costTracker, debugMessages };
+}
+
+async function makeCtx(logger: Logger): Promise<RunContext> {
+  return {
+    runId: "test-max-val-retries",
+    debugDir: await Deno.makeTempDir({ prefix: "test-max-val-retries-" }),
+    logger,
+    startTime: new Date(),
+  } as unknown as RunContext;
+}
+
+function makeAlwaysFailEngine(): { engine: LlmEngine; callCount: () => number } {
+  let calls = 0;
+  const engine: LlmEngine = {
+    streamText: () => ({}) as never,
+    generateText: () => {
+      calls++;
+      throw new NoObjectGeneratedError({
+        message: "Response did not match schema",
+        text: '{"bad": true}',
+        response: {
+          id: `resp-${calls}`,
+          modelId: "gpt-4",
+          timestamp: new Date(),
+          headers: {},
+        },
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+          inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+          outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+        },
+        finishReason: "stop",
+      });
+    },
+  };
+  return { engine, callCount: () => calls };
+}
+
+function makeFailThenSucceedEngine(failCount: number): { engine: LlmEngine; callCount: () => number } {
+  let calls = 0;
+  const validResponse = { value: 42 };
+  const engine: LlmEngine = {
+    streamText: () => ({}) as never,
+    generateText: () => {
+      calls++;
+      if (calls <= failCount) {
+        throw new NoObjectGeneratedError({
+          message: "Response did not match schema",
+          text: '{"value": "not-a-number"}',
+          response: {
+            id: `resp-${calls}`,
+            modelId: "gpt-4",
+            timestamp: new Date(),
+            headers: {},
+          },
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+            inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+            outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+          },
+          finishReason: "stop",
+        });
+      }
+      return Promise.resolve({
+        text: JSON.stringify(validResponse),
+        output: validResponse,
+        finishReason: "stop",
+        usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+        steps: [{ text: JSON.stringify(validResponse), output: validResponse }],
+        // deno-lint-ignore no-explicit-any
+      } as any);
+    },
+  };
+  return { engine, callCount: () => calls };
+}
+
+/**
+ * Creates a fake StreamTextResult for streaming structured tests.
+ */
+function makeFakeStreamResult(opts: {
+  textChunks: string[];
+  output?: unknown;
+  outputError?: Error;
+  inputTokens?: number;
+  outputTokens?: number;
+}) {
+  const {
+    textChunks,
+    output = null,
+    outputError,
+    inputTokens = 10,
+    outputTokens = 20,
+  } = opts;
+
+  const fullText = textChunks.join("");
+
+  async function* makeTextStream() {
+    for (const chunk of textChunks) {
+      yield chunk;
+    }
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async function* makeFullStream(): AsyncIterable<any> {
+    for (const chunk of textChunks) {
+      yield { type: "text-delta", textDelta: chunk };
+    }
+    yield {
+      type: "finish",
+      finishReason: "stop",
+      usage: { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens },
+    };
+  }
+
+  return {
+    textStream: makeTextStream(),
+    fullStream: makeFullStream(),
+    text: Promise.resolve(fullText),
+    output: outputError ? Promise.reject(outputError) : Promise.resolve(output),
+    usage: Promise.resolve({ inputTokens, outputTokens, totalTokens: inputTokens + outputTokens }),
+    toolCalls: Promise.resolve([]),
+    toolResults: Promise.resolve([]),
+    steps: Promise.resolve([]),
+    finishReason: Promise.resolve("stop"),
+    rawResponse: Promise.resolve(undefined),
+    providerMetadata: Promise.resolve(undefined),
+    experimental_providerMetadata: Promise.resolve(undefined),
+    // deno-lint-ignore no-explicit-any
+  } as any;
+}
+
+// --- Non-streaming tests ---
+
+Deno.test("Non-streaming: default maxValidationRetries is 3 when parameter omitted", async () => {
+  const { logger, costTracker } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+  const schema = z.object({ value: z.number() });
+
+  const { engine, callCount } = makeAlwaysFailEngine();
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = engine;
+
+  const result = await requester({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-default-retries",
+    schema,
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  // Should have made exactly 3 attempts (the default MAX_RETRIES)
+  expect(callCount()).toBe(3);
+  expect(result.validationError).toBeDefined();
+
+  await Deno.remove(ctx.debugDir, { recursive: true });
+});
+
+Deno.test("Non-streaming: maxValidationRetries=5 makes 5 attempts before giving up", async () => {
+  const { logger, costTracker } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+  const schema = z.object({ value: z.number() });
+
+  const { engine, callCount } = makeAlwaysFailEngine();
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key&maxValidationRetries=5"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = engine;
+
+  const result = await requester({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-custom-retries-5",
+    schema,
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  // Should have made exactly 5 attempts
+  expect(callCount()).toBe(5);
+  expect(result.validationError).toBeDefined();
+
+  await Deno.remove(ctx.debugDir, { recursive: true });
+});
+
+Deno.test("Non-streaming: maxValidationRetries=1 makes only 1 attempt", async () => {
+  const { logger, costTracker } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+  const schema = z.object({ value: z.number() });
+
+  const { engine, callCount } = makeAlwaysFailEngine();
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key&maxValidationRetries=1"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = engine;
+
+  const result = await requester({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-custom-retries-1",
+    schema,
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  expect(callCount()).toBe(1);
+  expect(result.validationError).toBeDefined();
+
+  await Deno.remove(ctx.debugDir, { recursive: true });
+});
+
+Deno.test("Non-streaming: success on attempt 4 with maxValidationRetries=5", async () => {
+  const { logger, costTracker } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+  const schema = z.object({ value: z.number() });
+
+  // Fails 3 times, succeeds on 4th — would fail with default MAX_RETRIES=3
+  const { engine, callCount } = makeFailThenSucceedEngine(3);
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key&maxValidationRetries=5"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = engine;
+
+  const result = await requester({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-success-on-4th",
+    schema,
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  expect(callCount()).toBe(4);
+  expect(result.result).toEqual({ value: 42 });
+  expect(result.validationError).toBeUndefined();
+
+  await Deno.remove(ctx.debugDir, { recursive: true });
+});
+
+Deno.test("Non-streaming: log message reflects configured maxValidationRetries value", async () => {
+  const { logger, costTracker, debugMessages } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+  const schema = z.object({ value: z.number() });
+
+  const { engine } = makeFailThenSucceedEngine(0);
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key&maxValidationRetries=7"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = engine;
+
+  await requester({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-log-retries",
+    schema,
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  // The log message should contain maxValidationRetries=7
+  const logWithRetries = debugMessages.find(m => m.includes("maxValidationRetries=7"));
+  expect(logWithRetries).toBeDefined();
+
+  await Deno.remove(ctx.debugDir, { recursive: true });
+});
+
+Deno.test("Non-streaming: maxValidationRetries does not affect settings (HTTP retries stay separate)", async () => {
+  const { logger, costTracker } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+
+  // maxRetries=10 is for HTTP, maxValidationRetries=2 is for validation
+  const { engine } = makeAlwaysFailEngine();
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key&maxRetries=10&maxValidationRetries=2"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = engine;
+
+  const result = await requester({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-separate-retries",
+    schema: z.object({ value: z.number() }),
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  // Only 2 validation retries, not 10
+  expect(result.validationError).toBeDefined();
+
+  await Deno.remove(ctx.debugDir, { recursive: true });
+});
+
+// --- Streaming structured tests ---
+
+Deno.test("Streaming structured: default maxValidationRetries is 3 when parameter omitted", async () => {
+  const { logger, costTracker } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+  const schema = z.object({ value: z.number() });
+
+  let streamCallCount = 0;
+
+  const mockEngine: LlmEngine = {
+    generateText: () => Promise.resolve({}) as never,
+    streamText: () => {
+      streamCallCount++;
+      return makeFakeStreamResult({
+        textChunks: ['{"bad": true}'],
+        output: null,
+        outputError: new Error("validation failed"),
+      });
+    },
+  };
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = mockEngine;
+
+  const stream = requester.stream({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-stream-default-retries",
+    schema,
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  // Suppress unhandled rejections from all stream promises
+  stream.text.catch(() => {});
+  stream.usage.catch(() => {});
+  stream.estimatedCost.catch(() => {});
+  stream.newMessages.catch(() => {});
+  stream.steps.catch(() => {});
+  stream.toolCalls.catch(() => {});
+  stream.toolResults.catch(() => {});
+
+  try {
+    await stream.output;
+  } catch {
+    // Expected: validation did not pass after 3 attempts
+  }
+
+  expect(streamCallCount).toBe(3);
+});
+
+Deno.test("Streaming structured: maxValidationRetries=5 makes 5 attempts", async () => {
+  const { logger, costTracker } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+  const schema = z.object({ value: z.number() });
+
+  let streamCallCount = 0;
+
+  const mockEngine: LlmEngine = {
+    generateText: () => Promise.resolve({}) as never,
+    streamText: () => {
+      streamCallCount++;
+      return makeFakeStreamResult({
+        textChunks: ['{"bad": true}'],
+        output: null,
+        outputError: new Error("validation failed"),
+      });
+    },
+  };
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key&maxValidationRetries=5"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = mockEngine;
+
+  const stream = requester.stream({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-stream-custom-retries-5",
+    schema,
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  // Suppress unhandled rejections from all stream promises
+  stream.text.catch(() => {});
+  stream.usage.catch(() => {});
+  stream.estimatedCost.catch(() => {});
+  stream.newMessages.catch(() => {});
+  stream.steps.catch(() => {});
+  stream.toolCalls.catch(() => {});
+  stream.toolResults.catch(() => {});
+
+  try {
+    await stream.output;
+  } catch {
+    // Expected: validation did not pass after 5 attempts
+  }
+
+  expect(streamCallCount).toBe(5);
+});
+
+Deno.test("Streaming structured: maxValidationRetries=1 makes only 1 attempt", async () => {
+  const { logger, costTracker } = makeTestDeps();
+  const ctx = await makeCtx(logger);
+  const schema = z.object({ value: z.number() });
+
+  let streamCallCount = 0;
+
+  const mockEngine: LlmEngine = {
+    generateText: () => Promise.resolve({}) as never,
+    streamText: () => {
+      streamCallCount++;
+      return makeFakeStreamResult({
+        textChunks: ['{"bad": true}'],
+        output: null,
+        outputError: new Error("validation failed"),
+      });
+    },
+  };
+
+  const requester = createVercelRequester({
+    modelUri: ModelURI.parse("chat://openai/gpt-4?apiKey=test-key&maxValidationRetries=1"),
+    logger,
+    costTracker,
+    ctx,
+  });
+  requester.engine = mockEngine;
+
+  const stream = requester.stream({
+    messages: [{ role: "user", content: "give number" }],
+    identifier: "test-stream-custom-retries-1",
+    schema,
+    stageName: "test",
+    tools: undefined,
+    maxSteps: undefined,
+    settings: undefined,
+  });
+
+  // Suppress unhandled rejections from all stream promises
+  stream.text.catch(() => {});
+  stream.usage.catch(() => {});
+  stream.estimatedCost.catch(() => {});
+  stream.newMessages.catch(() => {});
+  stream.steps.catch(() => {});
+  stream.toolCalls.catch(() => {});
+  stream.toolResults.catch(() => {});
+
+  try {
+    await stream.output;
+  } catch {
+    // Expected: validation did not pass after 1 attempt
+  }
+
+  expect(streamCallCount).toBe(1);
+});
+
+// --- ModelURI parsing test ---
+
+Deno.test("ModelURI: maxValidationRetries is not placed into settings", () => {
+  const uri = ModelURI.parse("chat://openai/gpt-4?apiKey=test-key&maxValidationRetries=5&maxRetries=10&temperature=0.5");
+  // maxValidationRetries should be a URI param that does not pollute LlmSettings
+  expect(uri.params.get("maxValidationRetries")).toBe("5");
+  expect(uri.params.get("maxRetries")).toBe("10");
+  expect(uri.params.get("temperature")).toBe("0.5");
+});

--- a/src/llm/llm.ts
+++ b/src/llm/llm.ts
@@ -282,6 +282,8 @@ interface ParsedModelUri {
   readonly apiKey?: string;
   readonly baseURL?: string;
   readonly logVercelWarnings?: boolean;
+  /** Maximum number of validation retry attempts. Defaults to DEFAULT_MAX_VALIDATION_RETRIES. */
+  readonly maxValidationRetries: number;
   readonly params: Readonly<Record<string, string>>;
   readonly settings: LlmSettings;
 }
@@ -343,7 +345,7 @@ interface YamlLogAttempt {
   readonly error?: string;
 }
 
-const MAX_RETRIES = 3;
+const DEFAULT_MAX_VALIDATION_RETRIES = 3;
 const INITIAL_RETRY_DELAY = 1000;
 
 /**
@@ -388,6 +390,7 @@ function parseModelUri({ uri }: Readonly<{ uri: ModelURI }>): ParsedModelUri {
   const result: ParsedModelUri = {
     provider: uri.provider,
     modelName: uri.modelName,
+    maxValidationRetries: DEFAULT_MAX_VALIDATION_RETRIES,
     params: {},
     settings: {},
   };
@@ -400,6 +403,12 @@ function parseModelUri({ uri }: Readonly<{ uri: ModelURI }>): ParsedModelUri {
     else if (key === "baseURL") (result as { baseURL?: string }).baseURL = value;
     else if (key === "logVercelWarnings") {
       (result as { logVercelWarnings?: boolean }).logVercelWarnings = value !== "false";
+    }
+    else if (key === "maxValidationRetries") {
+      const numValue = Number(value);
+      if (!isNaN(numValue) && numValue >= 1) {
+        (result as { maxValidationRetries: number }).maxValidationRetries = numValue;
+      }
     }
     else if (["maxTokens", "temperature", "topP", "topK", "frequencyPenalty", "presencePenalty", "seed", "maxRetries", "timeout"].includes(key)) {
       const numValue = Number(value);
@@ -579,7 +588,7 @@ async function saveStreamYamlLog(
  * - Structured (with schema): buffered retry loop — consumer sees only the successful attempt.
  */
 function tryStreamText<T>(
-  { identifier, schema, tools, maxSteps, messages, ctx, modelInstance, maskedUri, costTracker, logger, settings, engine, _stageName }: Readonly<{
+  { identifier, schema, tools, maxSteps, messages, ctx, modelInstance, maskedUri, costTracker, logger, settings, engine, _stageName, maxValidationRetries }: Readonly<{
     identifier: string;
     schema: z.ZodType<T> | undefined;
     tools: Record<string, Tool> | undefined;
@@ -592,6 +601,7 @@ function tryStreamText<T>(
     logger: Logger;
     settings: LlmSettings | undefined;
     engine: LlmEngine;
+    maxValidationRetries: number;
     /** Stage name for future debug file logging (not yet used in streaming path). */
     _stageName: string;
   }>
@@ -756,7 +766,7 @@ function tryStreamText<T>(
   const workPromise: Promise<StructuredWorkResult<T>> = (async () => {
     const allMessages = [...messages];
 
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 1; attempt <= maxValidationRetries; attempt++) {
       const attemptStart = Date.now();
       const controller = new AbortController();
       // Guard flag: prevents abort() after the stream settles. See issue #6.
@@ -824,10 +834,10 @@ function tryStreamText<T>(
         });
 
         logger.debug(`[LLM] [run:${ctx.runId}] [id:${identifier}:${attempt}] Stream error: ${msg}`);
-        if (attempt >= MAX_RETRIES) {
+        if (attempt >= maxValidationRetries) {
           // Write YAML debug file before throwing
           await saveStreamYamlLog({ ctx, stageName: _stageName, yamlLogData: streamLogData, logger });
-          throw new Error(`Streaming structured output failed after ${MAX_RETRIES} attempts: ${msg}`);
+          throw new Error(`Streaming structured output failed after ${maxValidationRetries} attempts: ${msg}`);
         }
         allMessages.push({ role: "assistant", content: text || "" });
         allMessages.push({ role: "user", content: msg });
@@ -930,7 +940,7 @@ function tryStreamText<T>(
       allMessages.push({ role: "assistant", content: text || "" });
       allMessages.push({ role: "user", content: validationErrorMsg });
 
-      if (attempt < MAX_RETRIES) {
+      if (attempt < maxValidationRetries) {
         const delay = calculateRetryDelay({ attempt });
         await new Promise(r => setTimeout(r, delay));
       }
@@ -938,7 +948,7 @@ function tryStreamText<T>(
 
     // Write YAML debug file before throwing (all attempts exhausted)
     await saveStreamYamlLog({ ctx, stageName: _stageName, yamlLogData: streamLogData, logger });
-    throw new Error(`Streaming structured output failed: validation did not pass after ${MAX_RETRIES} attempts`);
+    throw new Error(`Streaming structured output failed: validation did not pass after ${maxValidationRetries} attempts`);
   })();
 
   // Return StreamResult with lazy async iterables backed by workPromise
@@ -987,7 +997,7 @@ function tryStreamText<T>(
  * .refine() and .superRefine().
  */
 async function tryGenerateJson<T>(
-  { identifier, schema, tools, maxSteps, attempt, messages, ctx, modelInstance, maskedUri, costTracker, logger, settings, engine }: Readonly<{
+  { identifier, schema, tools, maxSteps, attempt, messages, ctx, modelInstance, maskedUri, costTracker, logger, settings, engine, maxValidationRetries }: Readonly<{
     identifier: string;
     schema: z.ZodType<T> | undefined;
     tools: Record<string, Tool> | undefined;
@@ -1001,6 +1011,7 @@ async function tryGenerateJson<T>(
     logger: Logger;
     settings: LlmSettings | undefined;
     engine: LlmEngine;
+    maxValidationRetries: number;
   }>
 ): Promise<GenerateResult<T> & { logAttempt: YamlLogAttempt }> {
   const timestamp = new Date().toISOString();
@@ -1008,7 +1019,7 @@ async function tryGenerateJson<T>(
 
     try {
       logger.debug(
-        `[LLM] [run:${ctx.runId}] [id:${identifier}:${attempt}] 🚀 Request: model=${maskedUri}, maxRetries=${MAX_RETRIES}, timeout=${settings?.timeout ?? 30000}ms, attempt=${attempt}`
+        `[LLM] [run:${ctx.runId}] [id:${identifier}:${attempt}] 🚀 Request: model=${maskedUri}, maxValidationRetries=${maxValidationRetries}, timeout=${settings?.timeout ?? 30000}ms, attempt=${attempt}`
       );
 
       try {
@@ -1216,7 +1227,7 @@ async function tryGenerateJson<T>(
 export function createVercelRequester(params: LlmRequesterParams): LlmRequester {
   const { modelUri, logger, costTracker, ctx } = params;
   const parsed = parseModelUri({ uri: modelUri });
-  const { settings: defaultSettings } = parsed;
+  const { settings: defaultSettings, maxValidationRetries } = parsed;
 
   if (parsed.logVercelWarnings === false) {
     // deno-lint-ignore no-explicit-any
@@ -1268,7 +1279,7 @@ export function createVercelRequester(params: LlmRequesterParams): LlmRequester 
     await ensureDebugDir({ debugDir });
     await writeFile(logFile, createYamlLog({ logData }), "utf-8");
 
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 1; attempt <= maxValidationRetries; attempt++) {
       const result = await tryGenerateJson<T>({
         identifier,
         schema,
@@ -1282,7 +1293,8 @@ export function createVercelRequester(params: LlmRequesterParams): LlmRequester 
         costTracker,
         logger,
         settings: mergedSettings,
-        engine: requester.engine || defaultLlmEngine
+        engine: requester.engine || defaultLlmEngine,
+        maxValidationRetries,
       });
 
       // Update log file with attempt data
@@ -1305,7 +1317,7 @@ export function createVercelRequester(params: LlmRequesterParams): LlmRequester 
       }
       messages.push({ role: "user", content: result.validationError || "Invalid response received." });
 
-      if (attempt === MAX_RETRIES) return result;
+      if (attempt === maxValidationRetries) return result;
 
       const delay = calculateRetryDelay({ attempt });
       logger.warn(`🔄 Attempt ${attempt} failed, retrying in ${Math.round(delay)}ms`);
@@ -1344,6 +1356,7 @@ export function createVercelRequester(params: LlmRequesterParams): LlmRequester 
       settings: mergedSettings,
       engine: requester.engine || defaultLlmEngine,
       _stageName: stageName,
+      maxValidationRetries,
     });
   };
 

--- a/src/openrouter/openrouter.ts
+++ b/src/openrouter/openrouter.ts
@@ -100,7 +100,7 @@ interface YamlLogData {
 // Constants
 // ---------------------------------------------------------------------------
 
-const MAX_RETRIES = 3;
+const DEFAULT_MAX_VALIDATION_RETRIES = 3;
 const INITIAL_RETRY_DELAY = 1000;
 
 // ---------------------------------------------------------------------------
@@ -705,6 +705,12 @@ export function createOpenRouterRequester(
   const maskedUri = modelUri.toString();
   const modelName = modelUri.modelName; // e.g. "openai/gpt-4o"
 
+  // Parse maxValidationRetries from URI (controls schema validation retry count)
+  const maxValidationRetriesRaw = modelUri.params.get("maxValidationRetries");
+  const maxValidationRetries = maxValidationRetriesRaw
+    ? (Number(maxValidationRetriesRaw) >= 1 ? Number(maxValidationRetriesRaw) : DEFAULT_MAX_VALIDATION_RETRIES)
+    : DEFAULT_MAX_VALIDATION_RETRIES;
+
   // Build engine (real or injected for tests)
   const engine: OpenRouterEngine = providedEngine ?? {
     responseSend: async (request: OpenResponsesRequest & { stream?: false }): Promise<OpenResponsesNonStreamingResponse> => {
@@ -783,7 +789,7 @@ export function createOpenRouterRequester(
     let lastValidationError: string | undefined;
     let lastRawResponse: string | undefined;
 
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 1; attempt <= maxValidationRetries; attempt++) {
       const attemptTimestamp = new Date().toISOString();
       const attemptStart = Date.now();
 
@@ -994,7 +1000,7 @@ export function createOpenRouterRequester(
                 `[OpenRouter] [run:${ctx.runId}] [id:${identifier}:${attempt}] ⚠️ Validation failed: ${validationError}`,
               );
 
-              if (attempt < MAX_RETRIES) {
+              if (attempt < maxValidationRetries) {
                 // Self-correction: add error message for retry
                 currentMessages = [
                   ...currentMessages,
@@ -1043,7 +1049,7 @@ export function createOpenRouterRequester(
             };
             yamlLogData.attempts.push(attemptLog);
 
-            if (attempt < MAX_RETRIES) {
+            if (attempt < maxValidationRetries) {
               currentMessages = [
                 ...currentMessages,
                 { role: "assistant", content: finalText } as ModelMessage,
@@ -1127,7 +1133,7 @@ export function createOpenRouterRequester(
           `[OpenRouter] [run:${ctx.runId}] [id:${identifier}:${attempt}] ❌ Error: ${errorMsg}`,
         );
 
-        if (attempt < MAX_RETRIES) {
+        if (attempt < maxValidationRetries) {
           await sleep(INITIAL_RETRY_DELAY * Math.pow(2, attempt - 1));
           continue;
         }


### PR DESCRIPTION
## Summary

- Add `maxValidationRetries` URI parameter to control schema validation retry count independently from HTTP-level `maxRetries` (Vercel AI SDK)
- Default remains 3 when parameter is omitted, preserving full backward compatibility
- Applied to both Vercel AI SDK path (`llm.ts`) and native OpenRouter path (`openrouter.ts`)

## Usage

```
# Default: 3 validation retries (unchanged behavior)
openai/gpt-4?apiKey=...

# Custom: 5 validation retries
openai/gpt-4?apiKey=...&maxValidationRetries=5

# Both HTTP and validation retries configured independently
openai/gpt-4?maxRetries=10&maxValidationRetries=2
```

## Changes

| File | Change |
|------|--------|
| `src/llm/llm.ts` | Parse `maxValidationRetries` in `parseModelUri()`, thread through `tryGenerateJson`/`tryStreamText`, replace hardcoded `MAX_RETRIES` in all 3 retry loops, update log message |
| `src/openrouter/openrouter.ts` | Parse from URI params, replace `MAX_RETRIES` in all 4 retry locations |
| `src/llm/llm.max-validation-retries.test.ts` | 10 new tests: default/custom counts, non-streaming + streaming, log verification, settings isolation |
| `documents/design.md` | Updated retry logic description |
| `documents/requirements.md` | Updated FR-LLM-2 and FR-LLM-13 |
| `documents/vision.md` | Updated resilience description |

## Test Results

`deno task check`: 81 passed, 0 failed, 1 ignored (acceptance test skipped without API key), lint clean.

Closes #7